### PR TITLE
Upgrade to .NET 6

### DIFF
--- a/IEZettaiKillApp.Core/IEZettaiKillApp.Core.csproj
+++ b/IEZettaiKillApp.Core/IEZettaiKillApp.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/IEZettaiKillApp.Test/IEZettaiKillApp.Test.csproj
+++ b/IEZettaiKillApp.Test/IEZettaiKillApp.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/IEZettaiKillApp.Wpf/IEZettaiKillApp.Wpf.csproj
+++ b/IEZettaiKillApp.Wpf/IEZettaiKillApp.Wpf.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <PublishSingleFile>true</PublishSingleFile>
     <UseWPF>true</UseWPF>


### PR DESCRIPTION
### issue
Fixes #14 

### WHAT
Upgrade from .NET 5 to .NET 6.

### WHY
To stay up to date.

### HOW
Modified the .csproj files and compiled to verify that there's no errors.